### PR TITLE
dissoc :bearer-token when building proper-query

### DIFF
--- a/src/tentacles/core.clj
+++ b/src/tentacles/core.clj
@@ -134,7 +134,7 @@
               (seq headers)
               (assoc :headers headers))
         raw-query (:raw query)
-        proper-query (query-map (dissoc query :auth :oauth-token :all-pages
+        proper-query (query-map (dissoc query :auth :oauth-token :all-pages :bearer-token
                                         :accept :user-agent :otp
                                         :etag :if-modified-since
                                         :throw-exceptions :socket-timeout


### PR DESCRIPTION
Dissoc `:bearer-token` from query when building proper one